### PR TITLE
Feature more ddtable header

### DIFF
--- a/sphinx_sql/sphinx_sql.py
+++ b/sphinx_sql/sphinx_sql.py
@@ -30,9 +30,9 @@ class SqlDirective(Directive):
         # Match Group 1 for Object Type, Group 3 for Object Name
         # in cluster and catalog objects (e.g. database, role; extension, schema)
         'object_cluster_catalog': '(?<=create)\s+(\w+)\s*(IF NOT EXISTS)*\s?(\w+)',
-        # Match Group 1 for Object Type, Group 3 for Object Name
+        # Match Group 2 for Object Type, Group 4 for Object Name
         # in schema objects (e.g. table, view, function)
-        'object_schema': '(?<=create)\s*(\w+)\s*(IF NOT EXISTS)*\s?((\w*)\.(\w*))',
+        'object_schema': '(?<=create)\s*(OR REPLACE)?\s*(\w+)\s*(IF NOT EXISTS)*\s?((\w*)\.(\w*))',
         # Match Group 2 for distribution key, comma seperated for multiple keys
         'distributed_by': 'distributed by \(.*?\)',
         # Match Group 2 for partition type (range) Group 3 for parition key.
@@ -94,7 +94,7 @@ class SqlDirective(Directive):
             object_details = {}
             if self.obj_schema.findall(contents):
                 sql_type_schema = self.obj_schema.findall(contents)[0]
-                sql_type = (sql_type_schema[0], sql_type_schema[2], sql_type_schema[3], sql_type_schema[4])
+                sql_type = (sql_type_schema[1], sql_type_schema[3], sql_type_schema[4], sql_type_schema[5])
             elif self.obj_cluster_catalog.findall(contents):
                 sql_type_cluster_catalog = self.obj_cluster_catalog.findall(contents)[0]
                 # Create a tuple matching to length of obj_schema

--- a/sphinx_sql/sphinx_sql.py
+++ b/sphinx_sql/sphinx_sql.py
@@ -27,12 +27,12 @@ class SqlDirective(Directive):
     regex_dict = {
         # Full comment block
         'top_sql_block_comments': '(?s)/\*.*?\*/',
-        # Match Group 2 for Object Type, Group 3 for Object Name
-        #'object': '^(create\s*or\s*replace\s*|create\s*|create\s*external\s*)(\w*)\s*((\w*)\.(\w*)|(\w*))',
-        # Match cluster and catalog objects (e.g. database, role; extension, schema)
+        # Match Group 1 for Object Type, Group 3 for Object Name
+        # in cluster and catalog objects (e.g. database, role; extension, schema)
         'object_cluster_catalog': '(?<=create)\s+(\w+)\s*(IF NOT EXISTS)*\s?(\w+)',
-        # Match schema objects (e.g. table, view, function)
-        'object_schema': '(?<=create)(.*?)((\w*)\.(\w*))',
+        # Match Group 1 for Object Type, Group 3 for Object Name
+        # in schema objects (e.g. table, view, function)
+        'object_schema': '(?<=create)\s*(\w+)\s*(IF NOT EXISTS)*\s?((\w*)\.(\w*))',
         # Match Group 2 for distribution key, comma seperated for multiple keys
         'distributed_by': 'distributed by \(.*?\)',
         # Match Group 2 for partition type (range) Group 3 for parition key.
@@ -42,11 +42,6 @@ class SqlDirective(Directive):
         'comments': {
             'object_name': '(?<=Object Name:)(\s\S*)',
             'object_type': '(?<=Object Type:)(\s\S*)',
-            #'parameters': '(?s)(?<=parameters:)(.*?)(?=return:)',
-            #'return_type': 'Return:(.?\w.*)',
-            #'purpose': '(?s)(?<=purpose:)(.*?)((?=dependent objects:)|(?=\*/))',
-            #'dependancies': '(?s)(?<=objects:)(.*?)(?=changelog:)',
-            #changelog': '(?s)(?<=changelog:)(.*?)(?=\*)',
             'parameters': f'(?s)(?<=parameters:)(.*?){closing_regex}',
             'return_type': 'Return:(.?\w.*)',
             'purpose': f'(?s)(?<=purpose:)(.*?){closing_regex}',
@@ -98,15 +93,17 @@ class SqlDirective(Directive):
             contents = f.read()
             object_details = {}
             if self.obj_schema.findall(contents):
-                sql_type = self.obj_schema.findall(contents)[0]
+                sql_type_schema = self.obj_schema.findall(contents)[0]
+                sql_type = (sql_type_schema[0], sql_type_schema[2], sql_type_schema[3], sql_type_schema[4])
             elif self.obj_cluster_catalog.findall(contents):
                 sql_type_cluster_catalog = self.obj_cluster_catalog.findall(contents)[0]
+                # Create a tuple matching to length of obj_schema
                 sql_type = (sql_type_cluster_catalog[0], sql_type_cluster_catalog[2], '', '')
             try:
                 if 'sql_type' in locals():
                     # DDL file
                     # Read name and type from ANSI92 SQL objects first
-                    object_details['type'] = str(sql_type[0]).upper().replace('OR REPLACE','').replace('IF NOT EXISTS', '').strip()
+                    object_details['type'] = str(sql_type[0]).upper().strip()
                     object_details['name'] = str(sql_type[1]).lower().strip()
 
                     if object_details['type'] == 'TABLE':

--- a/sphinx_sql/sphinx_sql.py
+++ b/sphinx_sql/sphinx_sql.py
@@ -24,15 +24,21 @@ class SqlDirective(Directive):
 
     # Most of these regex strings should be case insesitive lookups
     closing_regex = '((?=return:)|(?=purpose:)|(?=dependent objects:)|(?=changelog:)|(?=parameters)|(?=\*/))'
+    special_obj_type = [
+        'external',
+        'foreign',
+        'materialized',
+    ]
     regex_dict = {
         # Full comment block
         'top_sql_block_comments': '(?s)/\*.*?\*/',
         # Match Group 1 for Object Type, Group 3 for Object Name
         # in cluster and catalog objects (e.g. database, role; extension, schema)
-        'object_cluster_catalog': '(?<=create)\s+(\w+)\s*(IF NOT EXISTS)*\s?(\w+)',
-        # Match Group 2 for Object Type, Group 4 for Object Name
+        'object_cluster_catalog': '(?<=create)\s+(\w+)\s*(if not exists)*\s?(\w+)',
+        # Match Group 2 (a predefined special object type, e.g. "materialized")
+        # and 3 for Object Type, Group 5 for Object Name
         # in schema objects (e.g. table, view, function)
-        'object_schema': '(?<=create)\s*(OR REPLACE)?\s*(\w+)\s*(IF NOT EXISTS)*\s?((\w*)\.(\w*))',
+        'object_schema': f'''(?<=create)\s*(or replace)?\s*({'|'.join(special_obj_type)})?\s*(\w+)\s*(if not exists)*\s?((\w*)\.(\w*))''',
         # Match Group 2 for distribution key, comma seperated for multiple keys
         'distributed_by': 'distributed by \(.*?\)',
         # Match Group 2 for partition type (range) Group 3 for parition key.
@@ -94,7 +100,7 @@ class SqlDirective(Directive):
             object_details = {}
             if self.obj_schema.findall(contents):
                 sql_type_schema = self.obj_schema.findall(contents)[0]
-                sql_type = (sql_type_schema[1], sql_type_schema[3], sql_type_schema[4], sql_type_schema[5])
+                sql_type = (f'{sql_type_schema[1]} {sql_type_schema[2]}', sql_type_schema[4], sql_type_schema[5], sql_type_schema[6])
             elif self.obj_cluster_catalog.findall(contents):
                 sql_type_cluster_catalog = self.obj_cluster_catalog.findall(contents)[0]
                 # Create a tuple matching to length of obj_schema

--- a/tests/fixture/Catalog/my_test_extension.sql
+++ b/tests/fixture/Catalog/my_test_extension.sql
@@ -1,0 +1,15 @@
+/*
+Purpose:
+This a new extension to show how auto documentation can add new objects quickly.
+Dependent Objects:
+    Type    |Name
+    Schema   | my_test_schema
+ChangeLog:
+	Date    |    Author    |    Ticket    |    Modification
+	2020-12-23    |  Developer_2  |   T-232    |    Initial Definition
+*/
+
+CREATE EXTENSION IF NOT EXISTS my_test_extension
+	  WITH SCHEMA my_test_schema
+	  VERSION '1.0.0'
+;

--- a/tests/fixture/Catalog/my_test_role.sql
+++ b/tests/fixture/Catalog/my_test_role.sql
@@ -1,0 +1,10 @@
+/*
+Purpose:
+This a new role to show how auto documentation can add new objects quickly.
+ChangeLog:
+	Date    |    Author    |    Ticket    |    Modification
+	2020-12-23    |  Developer_2  |   T-234    |    Initial Definition
+*/
+CREATE ROLE my_test_role WITH
+	INHERIT
+;

--- a/tests/fixture/Catalog/my_test_schema.sql
+++ b/tests/fixture/Catalog/my_test_schema.sql
@@ -1,0 +1,9 @@
+/*
+Purpose:
+This a new schema to show how auto documentation can add new objects quickly.
+ChangeLog:
+	Date    |    Author    |    Ticket    |    Modification
+	2020-12-23    |  Developer_2  |   T-235    |    Initial Definition
+*/
+
+CREATE SCHEMA IF NOT EXISTS my_test_schema;

--- a/tests/fixture/Catalog/my_test_user.sql
+++ b/tests/fixture/Catalog/my_test_user.sql
@@ -1,0 +1,16 @@
+/*
+Purpose:
+This a new user to show how auto documentation can add new objects quickly.
+It inherits permissions from my_role.
+Dependent Objects:
+    Type    |Name
+    Role    |my_test_role
+ChangeLog:
+	Date    |    Author    |    Ticket    |    Modification
+	2020-12-23    |  Developer_2  |   T-234    |    Initial Definition
+*/
+CREATE USER person_doe WITH
+    PASSWORD '1234pass'
+    LOGIN
+    ROLE an_other
+;

--- a/tests/fixture/Schema3/my_test_materialized_view.sql
+++ b/tests/fixture/Schema3/my_test_materialized_view.sql
@@ -1,0 +1,15 @@
+/*
+Purpose:
+This a new materialized view to show how auto documentation can add new objects quickly.
+Dependent Objects:
+    Type    |Name
+    Table   |my_test_schema.my_test_table
+ChangeLog:
+    Date    |    Author    |    Ticket    |    Modification
+    2020-11-24    |    Developer_2    |    T-237    |    Initial Definition
+*/
+
+CREATE MATERIALIZED VIEW my_test_schema.my_test_materialized_view AS
+    SELECT name FROM my_test_schema.my_test_table
+WITH NO DATA
+;

--- a/tests/fixture/Schema3/my_test_table.sql
+++ b/tests/fixture/Schema3/my_test_table.sql
@@ -1,0 +1,17 @@
+/*
+Purpose:
+This a new table to show how auto documentation can add new objects quickly.
+Dependent Objects:
+    Type    |Name
+    Schema   |my_test_schema
+ChangeLog:
+	Date    |    Author    |    Ticket    |    Modification
+	2020-10-26    |  Developer_2  |   T-220    |    Initial Definition
+*/
+CREATE TABLE IF NOT EXISTS my_test_schema.my_test_table (
+    name character varying,
+    value smallint,
+    object_owner character varying
+) DISTRIBUTED BY (name, value)
+PARTITION BY (object_owner)
+;

--- a/tests/fixture/Schema3/my_test_trigger.sql
+++ b/tests/fixture/Schema3/my_test_trigger.sql
@@ -1,0 +1,17 @@
+/*
+Purpose:
+This a new trigger to show how auto documentation can add new objects quickly.
+Dependent Objects:
+    Type    |Name
+    Table   |my_test_schema.my_test_table
+ChangeLog:
+    Date    |    Author    |    Ticket    |    Modification
+    2020-11-24    |    Developer_2    |    T-239    |    Initial Definition
+*/
+
+CREATE TRIGGER log_update
+    AFTER UPDATE ON my_schema.my_test_table
+    FOR EACH ROW
+    WHEN (OLD.* IS DISTINCT FROM NEW.*)
+    EXECUTE PROCEDURE log_my_test_table_update()
+;

--- a/tests/fixture/my_test_dml.sql
+++ b/tests/fixture/my_test_dml.sql
@@ -1,0 +1,12 @@
+/*
+Object Name: my_test_dml
+Object Type: DML
+Purpose:
+This a new view to show how auto documentation can add new objects quickly.
+
+ChangeLog:
+	Date    |    Author    |    Ticket    |    Modification
+	2020-10-26    |  Developer_2  |   T-220    |    Initial Definition
+*/
+
+SELECT * FROM my_test_schema.my_test_table;


### PR DESCRIPTION
Handle database cluster and schema objects, e.g. Roles, Extentions and Schemas.
Also handle "special" object types like Materialized Views (object names consisting of two words).

Add more examples to test the modifications and additions.